### PR TITLE
Privileged contexts

### DIFF
--- a/src/Ivy/Codegen.hs
+++ b/src/Ivy/Codegen.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ConstraintKinds #-}
 
 module Ivy.Codegen where
 
@@ -26,7 +29,35 @@ import           Ivy.Parser
 import           Ivy.Syntax
 --------------------------------------------------------------------------------
 
-binOp :: PrimType -> Instruction -> Integer -> Integer -> Evm Operand
+class ContextM m where
+  updateCtx :: (Context -> Context) -> m ()
+  lookup :: String -> m VariableStatus
+
+instance ContextM Evm where
+  updateCtx f =
+    env %= (\(ctx:xs) -> (f ctx:xs))
+  lookup name =
+    go =<< use env
+    where
+      go :: [Context] -> Evm VariableStatus
+      go [] = return NotDeclared
+      go (ctx:xs) =
+        case M.lookup name ctx of
+          Just (TFun retTy, FunAddr funAddr retAddr)   -> return (FunDef retTy funAddr retAddr)
+          Just (varTy, VarAddr varAddr) -> decideVar (varTy, varAddr)
+          Nothing -> go xs
+        where
+          decideVar (ty, Nothing)   = return (Decl ty)
+          decideVar (ty, Just addr) = return (Def ty addr)
+
+class Monad m => TcM m where
+  checkTyEq :: Name -> PrimType -> PrimType -> m ()
+
+instance TcM Evm where
+  checkTyEq name tyL tyR =
+    unless (tyL == tyR) $ throwError $ TypeMismatch name tyR tyL
+
+binOp :: (OpcodeM m, MemoryM m) => PrimType -> Instruction -> Integer -> Integer -> m Operand
 binOp t instr left right = do
   load (sizeof TInt) left
   load (sizeof TInt) right
@@ -45,17 +76,18 @@ initCodegenState = CodegenState
   , _pc          = 0
   }
 
-executeBlock :: Block -> Evm ()
+executeBlock :: CodegenM m => Block -> m ()
 executeBlock (Block stmts) = do
   env %= (M.empty :)
   mapM_ codegenTop' stmts
   env %= tail
 
-updateCtx :: (Context -> Context) -> Evm ()
-updateCtx f =
-  env %= (\(ctx:xs) -> (f ctx:xs))
-
-assign :: PrimType -> Name -> Integer -> Evm ()
+assign
+  :: (MonadError CodegenError m, ContextM m, TcM m, MemoryM m)
+  => PrimType
+  -> Name
+  -> Integer
+  -> m ()
 assign tyR name addr =
   lookup name >>= \case
     NotDeclared -> throwError (VariableNotDeclared name (TextDetails "assignment"))
@@ -67,43 +99,7 @@ assign tyR name addr =
       storeAddressed (sizeof tyL) addr oldAddr
       updateCtx (M.update (const (Just (tyL, VarAddr (Just addr)))) name)
 
-lookup :: String -> Evm VariableStatus
-lookup name =
-  go =<< use env
-  where
-    go :: [Context] -> Evm VariableStatus
-    go [] = return NotDeclared
-    go (ctx:xs) =
-      case M.lookup name ctx of
-        Just (TFun retTy, FunAddr funAddr retAddr)   -> return (FunDef retTy funAddr retAddr)
-        Just (varTy, VarAddr varAddr) -> decideVar (varTy, varAddr)
-        Nothing -> go xs
-      where
-        decideVar (ty, Nothing)   = return (Decl ty)
-        decideVar (ty, Just addr) = return (Def ty addr)
-
-        decide :: Maybe (PrimType, Maybe Integer) -> Maybe (PrimType, Maybe Integer) -> Evm VariableStatus
-        decide Nothing                   Nothing                = return NotDeclared
-        decide Nothing                   (Just (ty, Nothing))   = return $ Decl ty
-        decide Nothing                   (Just (ty, Just val))  = return $ Def ty val
-        decide (Just (ty, Nothing))      Nothing                = return $ Decl ty
-        decide (Just (_ty1, Nothing))    (Just (_ty2, Nothing)) = throwError (VariableAlreadyDeclared name)
-        decide (Just (ty1, Nothing))     (Just (ty2, Just val)) =
-          if ty1 == ty2
-             then return $ Def ty1 val
-             else throwError (ScopedTypeViolation name ty1 ty2)
-        decide (Just (ty, Just val))      Nothing                = return $ Def ty val
-        decide (Just (_ty1, Just val))    (Just (_ty2, Nothing)) = throwError (VariableAlreadyDeclared name)
-        decide (Just (ty1, Just _))       (Just (ty2, Just val)) =
-          if ty1 == ty2
-             then return $ Def ty1 val -- Local value overrides
-             else throwError (ScopedTypeViolation name ty1 ty2)
-
-checkTyEq :: Name -> PrimType -> PrimType -> Evm ()
-checkTyEq name tyL tyR =
-  unless (tyL == tyR) $ throwError $ TypeMismatch name tyR tyL
-
-codegenTop :: Stmt -> Evm ()
+codegenTop :: CodegenM m => Stmt -> m ()
 codegenTop (STimes until block) = do
   -- Assign target value
   op2 PUSH32 until
@@ -229,20 +225,20 @@ codegenTop (SFunDef name block@(Block body) retTyAnnot) = do
   updateCtx (M.insert name (TFun retTy, FunAddr funPc retAddr))
   return ()
     where
-      executeFunBlock :: Block -> Evm Operand
+      executeFunBlock :: forall m. CodegenM m => Block -> m Operand
       executeFunBlock (Block stmts) = do
         env %= (M.empty :)
         go stmts <* (env %= tail)
           where
-            go :: [Stmt] -> Evm Operand
+            go :: [Stmt] -> m Operand
             go []             = throwError NoReturnStatement
             go [SReturn expr] = codegenExpr expr
             go (stmt:xs)      = codegenTop' stmt >> go xs
 
 codegenTop (SExpr expr) = void (codegenExpr expr)
 
-estimateOffset :: Block -> Evm Integer
-estimateOffset block =
+estimateOffset :: (MonadError CodegenError m, MonadIO m, MonadState CodegenState m) => Block -> m Integer
+estimateOffset block = do
   get >>= liftIO . go block >>= eitherToError
     where
       go :: Block -> CodegenState -> IO (Either CodegenError Integer)
@@ -257,7 +253,8 @@ estimateOffset block =
             let diff = newPc - oldPc
             ((+ diff) <$> ) <$> go (Block xs) newState
 
-codegenExpr :: Expr -> Evm Operand
+type CodegenM m = (MonadIO m, MonadLogger m, OpcodeM m, MonadState CodegenState m, MemoryM m, MonadError CodegenError m, ContextM m, TcM m)
+codegenExpr :: CodegenM m => Expr -> m Operand
 codegenExpr expr@(EIdentifier name) = do
   lookup name >>= \case
     NotDeclared -> throwError (VariableNotDeclared name (ExprDetails expr))
@@ -309,10 +306,10 @@ codegenExpr expr@(EFunCall name) =
       return (Operand retTy retAddr)
     _ -> throwError $ InternalError "Function call's name lookup is neither NotDeclared nor FunDef."
 
-log :: Show a => T.Text -> a -> Evm ()
+log :: (Show a, MonadLogger m) => T.Text -> a -> m ()
 log desc k = logDebug $ "[" <> desc <> "]: " <> T.pack (show k)
 
-codegenTop' :: Stmt -> Evm ()
+codegenTop' :: CodegenM m => Stmt -> m ()
 codegenTop' stmt = do
   use env >>= log "env"
   codegenTop stmt

--- a/src/Ivy/Codegen/Memory.hs
+++ b/src/Ivy/Codegen/Memory.hs
@@ -51,7 +51,6 @@ instance MemoryM Evm where
 
   load size addr = do
     op2 PUSH32 (0x10 ^ (64 - 2 * sizeInt size))
-    logInfo $ "Loading with size: " <> T.pack (show (sizeInt size))
     op2 PUSH32 addr
     op MLOAD
     op DIV

--- a/src/Ivy/Codegen/Memory.hs
+++ b/src/Ivy/Codegen/Memory.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Ivy.Codegen.Memory where
 
@@ -11,6 +12,7 @@ import           Control.Monad.Logger.CallStack (logInfo)
 import           Data.Functor                   (($>))
 import qualified Data.Map                       as M
 import           Data.Monoid
+import           Control.Monad.State
 import qualified Data.Text                      as T
 --------------------------------------------------------------------------------
 import           Ivy.Codegen.Types
@@ -18,49 +20,111 @@ import           Ivy.EvmAPI.Instruction
 import           Ivy.Syntax
 --------------------------------------------------------------------------------
 
-storeAddressed
-  :: Size    -- Variable size
-  -> Integer -- Address of the value. Value should be loaded from this address
-  -> Integer -- Address to put value on
-  -> Evm ()
-storeAddressed size valAddr destAddr = do
-  -- Initial state
-  load size valAddr
-  op2 PUSH32 destAddr
-  storeMultibyte size
+class MemoryM m where
+  storeAddressed
+    :: Size    -- Variable size
+    -> Integer -- Address of the value. Value should be loaded from this address
+    -> Integer -- Address to put value on
+    -> m ()
+  load
+    :: Size
+    -> Integer
+    -> m ()
+  storeVal
+    :: Size    -- Variable size
+    -> Integer -- Actual value
+    -> Integer -- Address to put value on
+    -> m ()
+  alloc
+    :: Size
+    -> m Integer
+  storeMultibyte
+    :: Size
+    -> m ()
 
-load
-  :: Size
-  -> Integer
-  -> Evm ()
-load size addr = do
-  op2 PUSH32 (0x10 ^ (64 - 2 * sizeInt size))
-  logInfo $ "Loading with size: " <> T.pack (show (sizeInt size))
-  op2 PUSH32 addr
-  op MLOAD
-  op DIV
+instance MemoryM Evm where
+  storeAddressed size valAddr destAddr = do
+    -- Initial state
+    load size valAddr
+    op2 PUSH32 destAddr
+    storeMultibyte size
 
-storeVal
-  :: Size    -- Variable size
-  -> Integer -- Actual value
-  -> Integer -- Address to put value on
-  -> Evm ()
-storeVal size val destAddr = do
-  let endDest = sizeInt size + destAddr - 1 -- To store 8 byte on address 10, we start from 17 and go back to 10
-  op2 PUSH32 val
-  op2 PUSH32 endDest
-  op MSTORE8
-  forM_ [1..sizeInt size - 1] $ \i -> do
-    op2 PUSH32 (val `div` (0x100 ^ i))
-    op2 PUSH32 (endDest - i)
+  load size addr = do
+    op2 PUSH32 (0x10 ^ (64 - 2 * sizeInt size))
+    logInfo $ "Loading with size: " <> T.pack (show (sizeInt size))
+    op2 PUSH32 addr
+    op MLOAD
+    op DIV
+
+  storeVal size val destAddr = do
+    let endDest = sizeInt size + destAddr - 1 -- To store 8 byte on address 10, we start from 17 and go back to 10
+    op2 PUSH32 val
+    op2 PUSH32 endDest
     op MSTORE8
+    forM_ [1..sizeInt size - 1] $ \i -> do
+      op2 PUSH32 (val `div` (0x100 ^ i))
+      op2 PUSH32 (endDest - i)
+      op MSTORE8
+
+  alloc size = do
+    memPtrs <- use memPointers
+    case M.lookup size memPtrs of
+      Nothing -> throwError $ InternalError $ "Pointer does not exist: " <> show size
+      Just (MemBlock index alloc) ->
+        if totalMemBlockSize - alloc >= sizeInt size
+          then
+          let
+            newPos :: Integer = (alloc + sizeInt size)
+          in do
+            updateMemPointer size index newPos
+            let baseAddr = calcAddr index alloc
+            let targetAddr = calcAddr index newPos
+            markMemAlloc index targetAddr
+            return baseAddr
+        else do
+            newIndex <- findMemspace
+            let baseAddr = 0
+            let targetAddr = sizeInt size
+            updateMemPointer size newIndex targetAddr
+            markMemAlloc newIndex targetAddr
+            return (calcAddr newIndex baseAddr)
+
+  storeMultibyte size = do
+    op2 PUSH32 (sizeInt size - 1)
+    op ADD
+    replicateM_ (fromIntegral (sizeInt size)) $ do
+      -- Populate value and address for the next iteration
+      op DUP2
+      op DUP2
+
+      -- Actually store the value
+      op MSTORE8
+
+      -- Decrease position by one to go left one position
+      op2 PUSH32 0x01
+      op SWAP1
+      op SUB
+
+      -- Shift number 8 bits right
+      op2 PUSH32 0x100
+      op SWAP1
+      op SWAP2
+      op DIV
+
+      -- Swap to restore stack position which is like (address, value) instead of (value, address)
+      op SWAP1
+
+    -- Cleanup
+    op POP
+    op POP
 
 totalMemBlockSize :: Integer
 totalMemBlockSize = 32 -- There are 32 bytes in a block
 
 -- O(n)
 findMemspace
-  :: Evm Integer -- newIndex
+  :: (MonadState CodegenState m, MemoryM m)
+  => m Integer -- newIndex
 findMemspace = do
   mem <- use memory
   let msize = fromIntegral $ M.size mem
@@ -80,10 +144,11 @@ calcAddr index allocLen = index * totalMemBlockSize + allocLen
 
 -- O(logn)
 updateMemPointer
-  :: Size       -- Which mem pointer will be updated
+  :: (MonadState CodegenState m)
+  => Size       -- Which mem pointer will be updated
   -> Integer    -- Index of the block
   -> Integer    -- New allocated size
-  -> Evm ()
+  -> m ()
 updateMemPointer size index newAllocSize =
   memPointers %= M.alter alter' size
   where
@@ -93,37 +158,18 @@ updateMemPointer size index newAllocSize =
     alter' (Just (MemBlock old_index old_alloc)) =
       Just (MemBlock index newAllocSize)
 
-markMemAlloc :: Integer -> Integer -> Evm ()
+markMemAlloc
+  :: MonadState CodegenState m
+  => Integer
+  -> Integer
+  -> m ()
 markMemAlloc index alloc = memory %= M.alter (const (Just alloc)) index
 
-alloc :: Size -> Evm Integer
-alloc size = do
-  memPtrs <- use memPointers
-  case M.lookup size memPtrs of
-    Nothing -> throwError $ InternalError $ "Pointer does not exist: " <> show size
-    Just (MemBlock index alloc) ->
-      if totalMemBlockSize - alloc >= sizeInt size
-        then
-        let
-          newPos :: Integer = (alloc + sizeInt size)
-        in do
-          updateMemPointer size index newPos
-          let baseAddr = calcAddr index alloc
-          let targetAddr = calcAddr index newPos
-          markMemAlloc index targetAddr
-          return baseAddr
-      else do
-          newIndex <- findMemspace
-          let baseAddr = 0
-          let targetAddr = sizeInt size
-          updateMemPointer size newIndex targetAddr
-          markMemAlloc newIndex targetAddr
-          return (calcAddr newIndex baseAddr)
-
 allocBulk
-  :: Integer
+  :: (MonadState CodegenState m, MemoryM m)
+  => Integer
   -> Size
-  -> Evm Integer
+  -> m Integer
 allocBulk length size = do
   msize <- fromIntegral . M.size <$> use memory
   if sizeInt size * length <= totalMemBlockSize
@@ -158,7 +204,6 @@ boolToInt :: Bool -> Integer
 boolToInt True  = 1
 boolToInt False = 0
 
-
 {-|
 Given the size and necessary stack state, stores that much byte properly aligned.
 For instance, we want to store 2 bytes of data at 0x0000, so we have the following stack:
@@ -191,38 +236,6 @@ And the iterative process:
 -> EXIT
 
 -}
-storeMultibyte
-  :: Size
-  -> Evm ()
-storeMultibyte size = do
-  op2 PUSH32 (sizeInt size - 1)
-  op ADD
-  replicateM_ (fromIntegral (sizeInt size)) $ do
-    -- Populate value and address for the next iteration
-    op DUP2
-    op DUP2
-
-    -- Actually store the value
-    op MSTORE8
-
-    -- Decrease position by one to go left one position
-    op2 PUSH32 0x01
-    op SWAP1
-    op SUB
-
-    -- Shift number 8 bits right
-    op2 PUSH32 0x100
-    op SWAP1
-    op SWAP2
-    op DIV
-
-    -- Swap to restore stack position which is like (address, value) instead of (value, address)
-    op SWAP1
-
-  -- Cleanup
-  op POP
-  op POP
-
 sizeInt :: Size -> Integer
 sizeInt Size_1  = 1
 sizeInt Size_2  = 2

--- a/src/Ivy/Codegen/Types.hs
+++ b/src/Ivy/Codegen/Types.hs
@@ -11,8 +11,6 @@ module Ivy.Codegen.Types where
 import           Control.Arrow
 import           Control.Lens                   hiding (Context)
 import           Control.Monad.Except
-import           Control.Monad.Logger           hiding (logInfo)
-import           Control.Monad.Logger.CallStack (logInfo)
 import           Control.Monad.State
 import           Data.Functor                   (($>))
 import           Data.Functor.Identity
@@ -101,8 +99,8 @@ data CodegenState = CodegenState
 
 makeLenses ''CodegenState
 
-newtype Evm a = Evm { runEvm :: StateT CodegenState (LoggingT (ExceptT CodegenError IO)) a }
-  deriving (Functor, Applicative, Monad, MonadIO, MonadState CodegenState, MonadError CodegenError, MonadLogger)
+newtype Evm a = Evm { runEvm :: StateT CodegenState (Either CodegenError) a }
+  deriving (Functor, Applicative, Monad, MonadState CodegenState, MonadError CodegenError)
 
 type ScopeLevel = Int
 

--- a/src/Ivy/EvmAPI/Instruction.hs
+++ b/src/Ivy/EvmAPI/Instruction.hs
@@ -81,7 +81,7 @@ pcCost = snd . toInstrCode
 pcCosts :: [Instruction] -> Integer
 pcCosts = sum . map pcCost
 
--- Class of monads that can run opcodes
+-- | Class of monads that can run opcodes
 class Monad m => OpcodeM m where
   op :: Instruction -> m ()
   -- ^ Opcode without argument

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -39,7 +39,7 @@ instance Show Error where
 codegen :: Mode -> CodegenState -> [S.Stmt] -> ExceptT Error IO T.Text
 codegen _ _ [] = return ""
 codegen mode state (e:ex) = do
-  result <- liftIO $ runExceptT (runStdoutLoggingT (execStateT (runEvm (C.codegenTop' e)) state))
+  let result = execStateT (runEvm (C.codegenTop' e)) state
   case result of
     Left (Codegen -> err)       -> throwError err
     Right newState ->


### PR DESCRIPTION
This PR constraints some part of codes to take some actions, not all of them. Currently:

- **MemoryM:** Class of monads that can load, store and alloc memory
- **ContextM:** Class of monads that can lookup and update context
- **TcM:** Class of monads that can perform typechecking
- **OpcodeM:** Class of monads that can perform opcode operations (eg. `op ADD`, `op DIV`)