### PR TITLE
Internal func call

### DIFF
--- a/stdlib.ivy
+++ b/stdlib.ivy
@@ -15,10 +15,13 @@ int fib(int n) {
   int b = 1;
   int sum = 6;
   while (n > 1) {
-    sum = a + b;
+    sum = addvals(a, b);
     a = b;
     b = sum;
     n = n - 1;
+  };
+  if(false) {
+    sum = sum + 10;
   };
   return sum;
 }


### PR DESCRIPTION
In EVM, function calls are weird in the sense that they are just switch-case statements. We were already supporting outside-world function (message) calls, and with this PR, we support internal calls as well.